### PR TITLE
[1] Allow the link to 'Next' image to be customized when Facebook is not in English.

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,26 @@ You'll then be prompted to provide the folder/directory name you want the images
     Please enter the URL to the first image of the Facebook Photo Album you would like to download: https://facebook.com/photo.php?fbid=11111&set=a.222.333.444
 
 
+Not using Facebook in English
+-----------------------------
+
+The crawler will look for a link labeled _Next_ to find the next image.
+If your Facebook is in another language, please run the command using
+the `-x` or `--next` option, with the equivalent word for _Next_ in
+your language.
+
+Example for Spanish:
+
+```bash
+$ ./albumgrab --next="Siguiente"
+```
+
+or
+
+```bash
+$ ./albumgrab -x Siguiente
+```
+
 Notes
 -----
 


### PR DESCRIPTION
Fixes #1.

Example usage for Dutch:

```
$ ./albumgrab -x Volgende
```

Example usage for Arabic:

```
$ ./albumgrab --next="الصفحة التالية"
```
